### PR TITLE
Add GitHub Skills Activity - Fix Issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Fixes Issue #6: 🚨 Missing Activity: GitHub Skills

This PR adds the missing "GitHub Skills" activity that was announced by the principal but wasn't available on the signup page.

### Changes Made
- ✅ Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- ✅ Includes comprehensive description mentioning GitHub Certifications program
- ✅ Scheduled for Wednesdays 3:30-5:00 PM
- ✅ Maximum capacity set to 25 participants
- ✅ Ready for immediate student registration

### Details
- **Description**: "Learn practical coding and collaboration skills through GitHub. First part of our GitHub Certifications program to help with college applications."
- **Schedule**: Wednesdays, 3:30 PM - 5:00 PM  
- **Capacity**: 25 students maximum
- **Status**: Open for registration (no participants yet)

### Addresses Student Concerns
This resolves the time-sensitive issue raised by Hewbie C. (11th Grade Student) who couldn't find the announced GitHub Skills activity. The registration deadline is this week, so this fix is urgent.

### Testing
- ✅ API endpoint `/activities` now returns the new activity
- ✅ Activity appears in the dropdown for student registration
- ✅ No breaking changes to existing functionality

Closes #6